### PR TITLE
Sanitize juliaup path in zshrc

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -47,7 +47,7 @@ r() {
 ### Julia (managed by juliaup) ##################################################
 # >>> juliaup initialize >>>
 # !! Contents within this block are managed by juliaup !!
-path=('/home/tim/.juliaup/bin' $path)
+path=("$HOME/.juliaup/bin" $path)
 export PATH
 # <<< juliaup initialize <<<
 
@@ -66,15 +66,6 @@ export EDITOR=nvim
 export VISUAL=nvim
 
 ### Custom tooling paths / commands #############################################
-export CHEATDIR="$HOME/Documents/Cheatsheets"
-export EDITOR_CMD="nvim"
-export TERMINAL_CMD="kitty"
-export CHEATDIR="$HOME/Documents/Cheatsheets"
-export EDITOR_CMD="nvim"
-export TERMINAL_CMD="kitty"
-export CHEATDIR="$HOME/Documents/Cheatsheets"
-export EDITOR_CMD="nvim"
-export TERMINAL_CMD="kitty"
 export CHEATDIR="$HOME/Documents/Cheatsheets"
 export EDITOR_CMD="nvim"
 export TERMINAL_CMD="kitty"


### PR DESCRIPTION
## Summary
- replace the hardcoded juliaup path in the zsh configuration with a $HOME-based expansion
- deduplicate the cheatsheet-related environment exports so the public config is cleaner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6414a5d94832bb4684cff71063c6d